### PR TITLE
sys replaced with util.

### DIFF
--- a/terminal.js
+++ b/terminal.js
@@ -1,4 +1,4 @@
-var sys = require('sys');
+var sys = require('util');
     
 // Terminal object
 // Allows for controlling the terminal by outputting control characters


### PR DESCRIPTION
Node has renamed 'sys' to 'util', and made 'sys' print an error and run commands through 'util' instead.
